### PR TITLE
Specify seconds for Time creation

### DIFF
--- a/lib/reform/form/multi_parameter_attributes.rb
+++ b/lib/reform/form/multi_parameter_attributes.rb
@@ -36,6 +36,8 @@ Reform::Form.class_eval do
         if hour.blank? && minute.blank?
           Date.new(year.to_i, month.to_i, day.to_i) # TODO: test fails.
         else
+          Rails.logger.info "Debugging"
+          Rails.logger.info [year, month, day, hour, minute, 0]
           args = [year, month, day, hour, minute, 0].map(&:to_i)
           Time.zone ? Time.zone.local(*args) :
             Time.new(*args)

--- a/lib/reform/form/multi_parameter_attributes.rb
+++ b/lib/reform/form/multi_parameter_attributes.rb
@@ -36,7 +36,7 @@ Reform::Form.class_eval do
         if hour.blank? && minute.blank?
           Date.new(year.to_i, month.to_i, day.to_i) # TODO: test fails.
         else
-          args = [year, month, day, hour, minute].map(&:to_i)
+          args = [year, month, day, hour, minute, 0].map(&:to_i)
           Time.zone ? Time.zone.local(*args) :
             Time.new(*args)
         end


### PR DESCRIPTION
Otherwise the current system seconds is used
